### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/ArduPID/keywords.txt
+++ b/ArduPID/keywords.txt
@@ -18,7 +18,7 @@ AutoCompute	KEYWORD2
 Compute	KEYWORD2
 SetSaturation	KEYWORD2
 SetTunings	KEYWORD2
-SetBackCalc KEYWORD2
+SetBackCalc	KEYWORD2
 Reset	KEYWORD2
 GetKp	KEYWORD2
 GetKi	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords